### PR TITLE
feat(CamStreamerAPI): add loadAsNone flag to file audio source

### DIFF
--- a/doc/CamStreamerAPI.md
+++ b/doc/CamStreamerAPI.md
@@ -289,6 +289,7 @@ type TStream = {
               path: string;
               name: string;
               forceStereo: boolean;
+              loadAsNone?: boolean; // file settings are valid but should load as 'none'
           }
         | {
               source: 'url';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "camstreamerlib",
-    "version": "4.0.25",
+    "version": "4.0.26",
     "description": "Helper library for CamStreamer ACAP applications.",
     "prettier": "@camstreamer/prettier-config",
     "engine": {

--- a/src/types/CamStreamerAPI/streamCommonTypes.ts
+++ b/src/types/CamStreamerAPI/streamCommonTypes.ts
@@ -102,6 +102,7 @@ export const streamCommonSchema = z.object({
             name: z.string(),
             path: z.string(),
             forceStereo: z.boolean(),
+            loadAsNone: z.boolean().optional(), // file settings are valid but should load as 'none'
         }),
         z.object({
             source: z.literal('url'),

--- a/src/types/CamStreamerAPI/streamCommonTypes.ts
+++ b/src/types/CamStreamerAPI/streamCommonTypes.ts
@@ -108,7 +108,7 @@ export const streamCommonSchema = z.object({
             source: z.literal('url'),
             name: z.string(),
             url: z.string(),
-            avSyncMsec: z.number().int().nonnegative(),
+            avSyncMsec: z.number().int(),
             forceStereo: z.boolean(),
         }),
     ]),


### PR DESCRIPTION
Optional flag on the stream audio 'file' variant. When true, the UI should load the audio source as 'none' even though valid file settings are persisted.